### PR TITLE
Pin paramiko to version 2.4.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ RUN apk add --update --no-cache --virtual .deps build-base \
                                                 python-dev \
   && apk add --no-cache openssl-dev \
                         python \
-  && pip install paramiko \
+  && pip install --upgrade pip \
+  && pip install paramiko==2.4.1 \
   && apk del .deps
 
 COPY sshUsernameEnumExploit.py /sshUsernameEnumExploit.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-paramiko
+paramiko==2.4.1


### PR DESCRIPTION
This PR updates pip version to the latest and installs paramiko version 2.4.1.

Closes Rhynorater/CVE-2018-15473-Exploit#10