### PR TITLE
Set paramiko version to 2.0.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --update --no-cache --virtual .deps build-base \
                                                 python-dev \
   && apk add --no-cache openssl-dev \
                         python \
-  && pip install paramiko \
+  && pip install paramiko==2.0.8 \
   && apk del .deps
 
 COPY sshUsernameEnumExploit.py /sshUsernameEnumExploit.py


### PR DESCRIPTION
After attempting to run this image, the following error pops up:

```
$ docker run --rm -it cve2018-15473
Traceback (most recent call last):
  File "sshUsernameEnumExploit.py", line 33, in <module>
    old_parse_service_accept = paramiko.auth_handler.AuthHandler._handler_table[paramiko.common.MSG_SERVICE_ACCEPT]
TypeError: 'property' object has no attribute '__getitem__'
```
Per [this issue](https://github.com/paramiko/paramiko/issues/1314) the fix is to downgrade to Paramiko v2.0.8.